### PR TITLE
[Do not review] [Do not merge] Sandbox configuration for import-db

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -80,7 +80,7 @@
     # NumActivePersisters - this will set the number of persisters to keep active at a moment. This works even if
     # the node removes old epochs data or not. In case of a node which removes old epochs data, this value has to be
     # smaller or equal to the NumOfEpochsToKeep flag
-    NumActivePersisters = 60
+    NumActivePersisters = 3
 
     # FullArchiveNumActivePersisters represents the number of persisters to be kept in cache as to allow better response
     # to inquiring peers. This value will get multiplied by the number of persisters required by the node to function so

--- a/config.toml
+++ b/config.toml
@@ -75,7 +75,7 @@
 
     # NumEpochsToKeep - if the flag above is set to true, this will set the number of epochs to keep in the storage.
     # Epochs older that (current epoch - NumOfEpochsToKeep) will be removed
-    NumEpochsToKeep = 60
+    NumEpochsToKeep = 55
 
     # NumActivePersisters - this will set the number of persisters to keep active at a moment. This works even if
     # the node removes old epochs data or not. In case of a node which removes old epochs data, this value has to be
@@ -832,7 +832,7 @@
 
 [DbLookupExtensions]
     Enabled = true
-    DbLookupMaxActivePersisters = 10
+    DbLookupMaxActivePersisters = 3
     [DbLookupExtensions.MiniblocksMetadataStorageConfig.Cache]
         Name = "DbLookupExtensions.MiniblocksMetadataStorage"
         Capacity = 20000

--- a/config.toml
+++ b/config.toml
@@ -63,7 +63,7 @@
     # Applicable for both observers and validators
     # WARNING! Setting this to false will increase each epoch's directory size with the trie snapshot,
     # which might easily cause the node to run out of disk space.
-    AccountsTrieCleanOldEpochsData = true
+    AccountsTrieCleanOldEpochsData = false
 
     # AccountsTrieSkipRemovalCustomPattern represents the custom pattern that determines when AccountsTrie database
     # doesn't have to be cleaned
@@ -75,12 +75,12 @@
 
     # NumEpochsToKeep - if the flag above is set to true, this will set the number of epochs to keep in the storage.
     # Epochs older that (current epoch - NumOfEpochsToKeep) will be removed
-    NumEpochsToKeep = 4
+    NumEpochsToKeep = 32
 
     # NumActivePersisters - this will set the number of persisters to keep active at a moment. This works even if
     # the node removes old epochs data or not. In case of a node which removes old epochs data, this value has to be
     # smaller or equal to the NumOfEpochsToKeep flag
-    NumActivePersisters = 3
+    NumActivePersisters = 32
 
     # FullArchiveNumActivePersisters represents the number of persisters to be kept in cache as to allow better response
     # to inquiring peers. This value will get multiplied by the number of persisters required by the node to function so
@@ -674,7 +674,7 @@
     CheckpointRoundsModulus = 100
     CheckpointsEnabled = false
     SnapshotsEnabled = true
-    AccountsStatePruningEnabled = true
+    AccountsStatePruningEnabled = false
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5
     MaxPeerTrieLevelInMemory = 5
@@ -831,7 +831,7 @@
         MaxOpenFiles = 10
 
 [DbLookupExtensions]
-    Enabled = false
+    Enabled = true
     DbLookupMaxActivePersisters = 10
     [DbLookupExtensions.MiniblocksMetadataStorageConfig.Cache]
         Name = "DbLookupExtensions.MiniblocksMetadataStorage"

--- a/config.toml
+++ b/config.toml
@@ -75,12 +75,12 @@
 
     # NumEpochsToKeep - if the flag above is set to true, this will set the number of epochs to keep in the storage.
     # Epochs older that (current epoch - NumOfEpochsToKeep) will be removed
-    NumEpochsToKeep = 32
+    NumEpochsToKeep = 60
 
     # NumActivePersisters - this will set the number of persisters to keep active at a moment. This works even if
     # the node removes old epochs data or not. In case of a node which removes old epochs data, this value has to be
     # smaller or equal to the NumOfEpochsToKeep flag
-    NumActivePersisters = 32
+    NumActivePersisters = 60
 
     # FullArchiveNumActivePersisters represents the number of persisters to be kept in cache as to allow better response
     # to inquiring peers. This value will get multiplied by the number of persisters required by the node to function so

--- a/prefs.toml
+++ b/prefs.toml
@@ -2,7 +2,7 @@
    # DestinationShardAsObserver represents the desired shard when running as observer
    # value will be given as string. For example: "0", "1", "15", "metachain"
    # if "disabled" is provided then the node will start in the corresponding shard for its public key or 0 otherwise
-   DestinationShardAsObserver = "disabled"
+   DestinationShardAsObserver = "0"
 
    # NodeDisplayName represents the friendly name a user can pick for his node in the status monitor
    NodeDisplayName = ""


### PR DESCRIPTION
 - Mainnet, Shard 0 (as example). 
 - Disable runtime pruning of `AccountsTrie`.
 - Keep latest `N = 32` epochs.